### PR TITLE
Use regexes to match ALPN protocols

### DIFF
--- a/doc/debian/jitsi-meet/jitsi-meet.conf
+++ b/doc/debian/jitsi-meet/jitsi-meet.conf
@@ -11,9 +11,8 @@ stream {
     }
     # since 1.13.10
     map $ssl_preread_alpn_protocols $upstream {
-        "h2"            web;
-        "http/1.1"      web;
-        "h2,http/1.1"   web;
+        ~\bh2\b         web;
+        ~\bhttp/1.1\b   web;
         default         turn;
     }
 


### PR DESCRIPTION
Fixes #5649

nginx presents the client's list of ALPN protocols as $ssl_preread_alpn_protocols, a comma-separated string.  Use regular expressions to match each item in the list, rather than the exact value of the entire list at once.